### PR TITLE
Expose GraphQL Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,61 @@ Add the initial library fixture:
 ```
 
 Browse to `/admin/library/`
+
+## Sample Queries
+
+Retrieve a list of versions
+```
+{
+  versions {
+    edges {
+      node {
+        id
+        urn
+        metadata
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+```
+
+Retrieve books within a particular version:
+```
+{
+  books(version_Urn: "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2") {
+    edges {
+      node {
+        id
+        label
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+```
+
+Retrieve lines within a book within a particular version:
+```
+{
+  lines(version_Urn: "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2", book_Position: 1) {
+    edges {
+      node {
+        id
+        label
+        textContent
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+```

--- a/readhomer_atlas/library/models.py
+++ b/readhomer_atlas/library/models.py
@@ -42,7 +42,7 @@ class Book(models.Model):
 
     @property
     def label(self):
-        return f"{self.chapter_position}.{self.section_position}.{self.subsection_position}"
+        return f"{self.position}"
 
     def __str__(self):
         return f"{self.version} [book={self.position}]"

--- a/readhomer_atlas/library/schema.py
+++ b/readhomer_atlas/library/schema.py
@@ -1,0 +1,86 @@
+from graphene import ObjectType, String, relay
+from graphene.types import generic
+from graphene_django import DjangoObjectType
+from graphene_django.filter import DjangoFilterConnectionField
+
+from .models import Book, Line, Version
+
+
+class LimitedConnectionField(DjangoFilterConnectionField):
+    """
+    Ensures that queries without `first` or `last` return up to
+    `max_limit` results.
+    """
+
+    @classmethod
+    def connection_resolver(
+        cls,
+        resolver,
+        connection,
+        default_manager,
+        max_limit,
+        enforce_first_or_last,
+        filterset_class,
+        filtering_args,
+        root,
+        info,
+        **resolver_kwargs
+    ):
+        first = resolver_kwargs.get("first")
+        last = resolver_kwargs.get("last")
+        if not first and not last:
+            resolver_kwargs["first"] = max_limit
+
+        return super(LimitedConnectionField, cls).connection_resolver(
+            resolver,
+            connection,
+            default_manager,
+            max_limit,
+            enforce_first_or_last,
+            filterset_class,
+            filtering_args,
+            root,
+            info,
+            **resolver_kwargs
+        )
+
+
+class VersionNode(DjangoObjectType):
+    metadata = generic.GenericScalar()
+    books = LimitedConnectionField(lambda: BookNode)
+    lines = LimitedConnectionField(lambda: LineNode)
+
+    class Meta:
+        model = Version
+        interfaces = (relay.Node,)
+        filter_fields = ["name", "urn"]
+
+
+class BookNode(DjangoObjectType):
+    label = String()
+    lines = LimitedConnectionField(lambda: LineNode)
+
+    class Meta:
+        model = Book
+        interfaces = (relay.Node,)
+        filter_fields = ["position", "version__urn"]
+
+
+class LineNode(DjangoObjectType):
+    label = String()
+
+    class Meta:
+        model = Line
+        interfaces = (relay.Node,)
+        filter_fields = ["book__position", "version__urn"]
+
+
+class Query(ObjectType):
+    version = relay.Node.Field(VersionNode)
+    versions = LimitedConnectionField(VersionNode)
+
+    book = relay.Node.Field(BookNode)
+    books = LimitedConnectionField(BookNode)
+
+    line = relay.Node.Field(LineNode)
+    lines = LimitedConnectionField(LineNode)

--- a/readhomer_atlas/schema.py
+++ b/readhomer_atlas/schema.py
@@ -1,0 +1,12 @@
+import graphene
+
+import readhomer_atlas.library.schema
+
+
+class Query(readhomer_atlas.library.schema.Query, graphene.ObjectType):
+    # This class will inherit from multiple Queries
+    # as we begin to add more apps to our project
+    pass
+
+
+schema = graphene.Schema(query=Query)

--- a/readhomer_atlas/settings.py
+++ b/readhomer_atlas/settings.py
@@ -102,6 +102,7 @@ TEMPLATES = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -124,6 +125,7 @@ INSTALLED_APPS = [
     "django.contrib.sites",
     "django.contrib.staticfiles",
     # third party
+    "corsheaders",
     "django_extensions",
     # project
     "readhomer_atlas",
@@ -161,3 +163,5 @@ LOGGING = {
 FIXTURE_DIRS = [os.path.join(PROJECT_ROOT, "fixtures")]
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+CORS_ORIGIN_ALLOW_ALL = True

--- a/readhomer_atlas/settings.py
+++ b/readhomer_atlas/settings.py
@@ -127,6 +127,7 @@ INSTALLED_APPS = [
     # third party
     "corsheaders",
     "django_extensions",
+    "graphene_django",
     # project
     "readhomer_atlas",
     "readhomer_atlas.library",
@@ -165,3 +166,10 @@ FIXTURE_DIRS = [os.path.join(PROJECT_ROOT, "fixtures")]
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 CORS_ORIGIN_ALLOW_ALL = True
+
+GRAPHENE = {
+    "SCHEMA": "readhomer_atlas.schema.schema",
+    # setting RELAY_CONNECTION_MAX_LIMIT to None removes the limit; for backwards compatability with current API
+    # @@@ restore the limit
+    "RELAY_CONNECTION_MAX_LIMIT": None,
+}

--- a/readhomer_atlas/settings.py
+++ b/readhomer_atlas/settings.py
@@ -102,6 +102,7 @@ TEMPLATES = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -123,6 +124,8 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.sessions",
     "django.contrib.sites",
+    # override runserver static handling
+    "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     # third party
     "corsheaders",

--- a/readhomer_atlas/urls.py
+++ b/readhomer_atlas/urls.py
@@ -1,5 +1,9 @@
 from django.contrib import admin
 from django.urls import path
 
+from graphene_django.views import GraphQLView
 
-urlpatterns = [path("admin/", admin.site.urls)]
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("graphql/", GraphQLView.as_view(graphiql=True)),
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ django==2.2.3
 graphene-django==2.3.2
 gunicorn==19.9.0
 psycopg2-binary==2.8.3
+whitenoise==4.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 dj-database-url==0.5.0
+django-cors-headers==3.0.2
 django-extensions==2.1.9
+django-filter==2.1.0
 django==2.2.3
+graphene-django==2.3.2
 gunicorn==19.9.0
 psycopg2-binary==2.8.3


### PR DESCRIPTION
Exposes a GraphQL endpoint powered by [**graphene-django**](https://github.com/graphql-python/graphene-django).

The GraphQL object types are implemented as Relay nodes.

The `LimitedConnectionField` connection type has been added to ensure that the overall `GRAPHENE.RELAY_CONNECTION_MAX_LIMIT` setting is respected.

That limit is currently not enforced, but it is recommended that a production ATLAS instance enforces that limit and any clients querying ATLAS implement the [Relay Cursor Connections Specification](https://facebook.github.io/relay/graphql/connections.htm) to paginate all queries.

**Other Features**

- Add `django-cors-headers` to handle CORS headers (allowing SV instances to query ATLAS across domains)
- Add `whitenoise` to serve `graphene-django` static dependencies (GraphiQL endpoint)