### PR TITLE
Improve Node metadata

### DIFF
--- a/readhomer_atlas/library/importers/versions.py
+++ b/readhomer_atlas/library/importers/versions.py
@@ -83,8 +83,8 @@ class CTSImporter:
         self.nodes = nodes
         self.urn = URN(self.version_data["urn"].strip())
         self.work_urn = self.urn.up_to(self.urn.WORK)
-        self.name = get_first_value_for_language(
-            self.library.works[self.work_urn]["title"], "eng"
+        self.label = get_first_value_for_language(
+            version_data["label"], "eng"
         )
         self.citation_scheme = self.version_data["citation_scheme"]
         self.metadata = self.get_version_metadata()
@@ -142,7 +142,7 @@ class CTSImporter:
             # "pass through" via GraphQL vs
             # apply to particular node kinds in the heirarchy
             "citation_scheme": self.citation_scheme,
-            "work_title": self.name,
+            "label": self.label,
             "first_passage_urn": self.version_data["first_passage_urn"],
             "default_toc_urn": self.version_data.get("default_toc_urn"),
         }
@@ -256,7 +256,7 @@ class CTSImporter:
                 self.generate_branch(line)
 
         count = self.finalize()
-        print(f"{self.name}: {count} nodes.", file=sys.stderr)
+        print(f"{self.label}: {count} nodes.", file=sys.stderr)
 
 
 def resolve_library():

--- a/readhomer_atlas/library/importers/versions.py
+++ b/readhomer_atlas/library/importers/versions.py
@@ -83,9 +83,7 @@ class CTSImporter:
         self.nodes = nodes
         self.urn = URN(self.version_data["urn"].strip())
         self.work_urn = self.urn.up_to(self.urn.WORK)
-        self.label = get_first_value_for_language(
-            version_data["label"], "eng"
-        )
+        self.label = get_first_value_for_language(version_data["label"], "eng")
         self.citation_scheme = self.version_data["citation_scheme"]
         self.idx_lookup = defaultdict(int)
 
@@ -137,15 +135,11 @@ class CTSImporter:
 
     def get_textgroup_metadata(self, urn):
         metadata = self.library.text_groups[urn.up_to(URN.TEXTGROUP)]
-        return {
-            "label" : get_first_value_for_language(metadata["name"], "eng")
-        }
+        return {"label": get_first_value_for_language(metadata["name"], "eng")}
 
     def get_work_metadata(self, urn):
         metadata = self.library.works[urn.up_to(URN.WORK)]
-        return {
-            "label" : get_first_value_for_language(metadata["title"], "eng")
-        }
+        return {"label": get_first_value_for_language(metadata["title"], "eng")}
 
     def get_version_metadata(self):
         return {

--- a/readhomer_atlas/library/importers/versions.py
+++ b/readhomer_atlas/library/importers/versions.py
@@ -87,7 +87,6 @@ class CTSImporter:
             version_data["label"], "eng"
         )
         self.citation_scheme = self.version_data["citation_scheme"]
-        self.metadata = self.get_version_metadata()
         self.idx_lookup = defaultdict(int)
 
         self.nodes_to_create = []
@@ -135,6 +134,18 @@ class CTSImporter:
 
     def get_urn_scheme(self, node_urn):
         return [*self.get_root_urn_scheme(node_urn), *self.citation_scheme]
+
+    def get_textgroup_metadata(self, urn):
+        metadata = self.library.text_groups[urn.up_to(URN.TEXTGROUP)]
+        return {
+            "label" : get_first_value_for_language(metadata["name"], "eng")
+        }
+
+    def get_work_metadata(self, urn):
+        metadata = self.library.works[urn.up_to(URN.WORK)]
+        return {
+            "label" : get_first_value_for_language(metadata["title"], "eng")
+        }
 
     def get_version_metadata(self):
         return {
@@ -198,8 +209,12 @@ class CTSImporter:
 
             if kind not in self.citation_scheme:
                 data.update({"urn": self.get_partial_urn(kind, node_urn)})
-                if kind == "version":
-                    data.update({"metadata": self.metadata})
+                if kind == "textgroup":
+                    data.update({"metadata": self.get_textgroup_metadata(node_urn)})
+                elif kind == "work":
+                    data.update({"metadata": self.get_work_metadata(node_urn)})
+                elif kind == "version":
+                    data.update({"metadata": self.get_version_metadata()})
             else:
                 ref_index = self.citation_scheme.index(kind)
                 ref = ".".join(node_urn.passage_nodes[: ref_index + 1])

--- a/readhomer_atlas/library/models.py
+++ b/readhomer_atlas/library/models.py
@@ -291,6 +291,7 @@ class Node(MP_Node):
     ref = models.CharField(max_length=255, blank=True, null=True)
     rank = models.IntegerField(blank=True, null=True)
     text_content = models.TextField(blank=True, null=True)
+    # @@@ we may want to furthe de-norm label from metadata
     metadata = JSONField(default=dict, blank=True, null=True)
 
     alphabet = settings.NODE_ALPHABET

--- a/readhomer_atlas/library/models.py
+++ b/readhomer_atlas/library/models.py
@@ -299,8 +299,8 @@ class Node(MP_Node):
         return f"{self.kind}: {self.urn}"
 
     @property
-    def name(self):
-        return self.metadata.get("work_title")
+    def label(self):
+        return self.metadata.get("label", self.urn)
 
     @classmethod
     def dump_tree(cls, root=None, up_to=None, to_camel=True):

--- a/readhomer_atlas/tests/constants.py
+++ b/readhomer_atlas/tests/constants.py
@@ -55,7 +55,7 @@ VERSION_DATA = {
     "version_kind": "edition",
     "first_passage_urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1-1.7",
     "citation_scheme": ["book", "line"],
-    "title": [{"lang": "eng", "value": "Iliad, Homeri Opera"}],
+    "label": [{"lang": "eng", "value": "Iliad, Homeri Opera"}],
     "description": [
         {
             "lang": "eng",
@@ -66,11 +66,10 @@ VERSION_DATA = {
 
 VERSION_METADATA = {
     "citation_scheme": ["book", "line"],
-    "work_title": "Iliad",
+    "label": "Iliad, Homeri Opera",
     "first_passage_urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1-1.7",
     "default_toc_urn": None,
 }
-
 LIBRARY_DATA = {
     "text_groups": {
         "urn:cts:greekLit:tlg0012:": {
@@ -93,7 +92,7 @@ LIBRARY_DATA = {
                     "version_kind": "edition",
                     "first_passage_urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1-1.7",
                     "citation_scheme": ["book", "line"],
-                    "title": [{"lang": "eng", "value": "Iliad, Homeri Opera"}],
+                    "label": [{"lang": "eng", "value": "Iliad, Homeri Opera"}],
                     "description": [
                         {
                             "lang": "eng",
@@ -108,7 +107,7 @@ LIBRARY_DATA = {
             "groupUrn": "urn:cts:greekLit:tlg0012:",
             "node_kind": "work",
             "lang": "grc",
-            "title": [{"lang": "eng", "value": "Odyssey"}],
+            "label": [{"lang": "eng", "value": "Odyssey"}],
             "versions": [
                 {
                     "urn": "urn:cts:greekLit:tlg0012.tlg002.perseus-grc2:",
@@ -116,7 +115,7 @@ LIBRARY_DATA = {
                     "version_kind": "edition",
                     "first_passage_urn": "urn:cts:greekLit:tlg0012.tlg002.perseus-grc2:1.1-1.10",
                     "citation_scheme": ["book", "line"],
-                    "title": [
+                    "label": [
                         {"lang": "eng", "value": "Odyssey, Loeb classical library"}
                     ],
                     "description": [
@@ -137,7 +136,7 @@ LIBRARY_DATA = {
             "version_kind": "edition",
             "first_passage_urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1-1.7",
             "citation_scheme": ["book", "line"],
-            "title": [{"lang": "eng", "value": "Iliad, Homeri Opera"}],
+            "label": [{"lang": "eng", "value": "Iliad, Homeri Opera"}],
             "description": [
                 {
                     "lang": "eng",
@@ -152,7 +151,7 @@ LIBRARY_DATA = {
             "version_kind": "edition",
             "first_passage_urn": "urn:cts:greekLit:tlg0012.tlg002.perseus-grc2:1.1-1.10",
             "citation_scheme": ["book", "line"],
-            "title": [{"lang": "eng", "value": "Odyssey, Loeb classical library"}],
+            "label": [{"lang": "eng", "value": "Odyssey, Loeb classical library"}],
             "description": [
                 {
                     "lang": "eng",

--- a/readhomer_atlas/tests/test_importer.py
+++ b/readhomer_atlas/tests/test_importer.py
@@ -18,8 +18,16 @@ def test_destructure():
     ) == [
         {"kind": "nid", "urn": "urn:cts:"},
         {"kind": "namespace", "urn": "urn:cts:greekLit:"},
-        {"kind": "textgroup", "urn": "urn:cts:greekLit:tlg0012:"},
-        {"kind": "work", "urn": "urn:cts:greekLit:tlg0012.tlg001:"},
+        {
+            "kind": "textgroup",
+            "urn": "urn:cts:greekLit:tlg0012:",
+            "metadata": {"label": "Homer"},
+        },
+        {
+            "kind": "work",
+            "urn": "urn:cts:greekLit:tlg0012.tlg001:",
+            "metadata": {"label": "Iliad"},
+        },
         {
             "kind": "version",
             "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:",
@@ -55,8 +63,16 @@ def test_destructure_alphanumeric():
     assert CTSImporter(library, version_data).destructure_urn(urn, tokens) == [
         {"kind": "nid", "urn": "urn:cts:"},
         {"kind": "namespace", "urn": "urn:cts:greekLit:"},
-        {"kind": "textgroup", "urn": "urn:cts:greekLit:tlg0012:"},
-        {"kind": "work", "urn": "urn:cts:greekLit:tlg0012.tlg001:"},
+        {
+            "kind": "textgroup",
+            "urn": "urn:cts:greekLit:tlg0012:",
+            "metadata": {"label": "Homer"},
+        },
+        {
+            "kind": "work",
+            "urn": "urn:cts:greekLit:tlg0012.tlg001:",
+            "metadata": {"label": "Iliad"},
+        },
         {
             "kind": "version",
             "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:",
@@ -107,12 +123,22 @@ def test_importer(mock_node, mock_generate, mock_open):
         ),
         mock.call(
             2,
-            {"kind": "textgroup", "urn": "urn:cts:greekLit:tlg0012:", "idx": 0},
+            {
+                "kind": "textgroup",
+                "urn": "urn:cts:greekLit:tlg0012:",
+                "metadata": {"label": "Homer"},
+                "idx": 0,
+            },
             "urn:cts:greekLit:",
         ),
         mock.call(
             3,
-            {"kind": "work", "urn": "urn:cts:greekLit:tlg0012.tlg001:", "idx": 0},
+            {
+                "kind": "work",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001:",
+                "metadata": {"label": "Iliad"},
+                "idx": 0,
+            },
             "urn:cts:greekLit:tlg0012:",
         ),
         mock.call(
@@ -122,7 +148,7 @@ def test_importer(mock_node, mock_generate, mock_open):
                 "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:",
                 "metadata": {
                     "citation_scheme": ["book", "line"],
-                    "work_title": "Iliad",
+                    "label": "Iliad, Homeri Opera",
                     "first_passage_urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1-1.7",
                     "default_toc_urn": None,
                 },
@@ -252,12 +278,22 @@ def test_importer_with_exemplar(mock_node, mock_generate, mock_open):
         ),
         mock.call(
             2,
-            {"kind": "textgroup", "urn": "urn:cts:greekLit:tlg0012:", "idx": 0},
+            {
+                "kind": "textgroup",
+                "urn": "urn:cts:greekLit:tlg0012:",
+                "metadata": {"label": "Homer"},
+                "idx": 0,
+            },
             "urn:cts:greekLit:",
         ),
         mock.call(
             3,
-            {"kind": "work", "urn": "urn:cts:greekLit:tlg0012.tlg001:", "idx": 0},
+            {
+                "kind": "work",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001:",
+                "metadata": {"label": "Iliad"},
+                "idx": 0,
+            },
             "urn:cts:greekLit:tlg0012:",
         ),
         mock.call(
@@ -267,7 +303,7 @@ def test_importer_with_exemplar(mock_node, mock_generate, mock_open):
                 "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:",
                 "metadata": {
                     "citation_scheme": ["book", "line"],
-                    "work_title": "Iliad",
+                    "label": "Iliad, Homeri Opera",
                     "first_passage_urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1-1.7",
                     "default_toc_urn": None,
                 },

--- a/readhomer_atlas/tests/test_importer_fuzz.py
+++ b/readhomer_atlas/tests/test_importer_fuzz.py
@@ -46,7 +46,7 @@ def _get_library(urn):
                 "version_kind": "edition",
                 "first_passage_urn": f"{version_urn}1.1-1.5",
                 "citation_scheme": None,
-                "title": [{"lang": "eng", "value": "Some Title"}],
+                "label": [{"lang": "eng", "value": "Some Title"}],
                 "description": [{"lang": "eng", "value": "Some description."}],
             }
         },


### PR DESCRIPTION
## What's in this PR?

Updates ingestion to populate `metadata.label` for `textgroup`, `work` and `version` nodes.