### PR TITLE
Fix ImageAnnotation image_identifer URLs

### DIFF
--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA012RN_0013.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA012RN_0013.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA012RN_0013",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA012RN-0013/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA012RN-0013/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA012RN-0013/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:12r"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA033VN_0535.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA033VN_0535.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA033VN_0535",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA033VN-0535/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA033VN-0535/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA033VN-0535/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:33v"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA034RN_0035.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA034RN_0035.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA034RN_0035",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA034RN-0035/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA034RN-0035/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA034RN-0035/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:34r"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA034VN_0536.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA034VN_0536.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA034VN_0536",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA034VN-0536/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA034VN-0536/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA034VN-0536/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:34v"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA035RN_0036.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA035RN_0036.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA035RN_0036",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA035RN-0036/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA035RN-0036/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA035RN-0036/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:35r"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA035VN_0537.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA035VN_0537.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA035VN_0537",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA035VN-0537/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA035VN-0537/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA035VN-0537/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:35v"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA036RN_0037.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA036RN_0037.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA036RN_0037",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA036RN-0037/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA036RN-0037/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA036RN-0037/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:36r"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA036VN_0538.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA036VN_0538.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA036VN_0538",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA036VN-0538/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA036VN-0538/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA036VN-0538/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:36v"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA037RN_0038.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA037RN_0038.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA037RN_0038",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA037RN-0038/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA037RN-0038/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA037RN-0038/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:37r"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA037VN_0539.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA037VN_0539.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA037VN_0539",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA037VN-0539/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA037VN-0539/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA037VN-0539/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:37v"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA038RN_0039.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA038RN_0039.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA038RN_0039",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA038RN-0039/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA038RN-0039/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA038RN-0039/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:38r"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA038VN_0540.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA038VN_0540.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA038VN_0540",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA038VN-0540/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA038VN-0540/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA038VN-0540/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:38v"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA039RN_0040.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA039RN_0040.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA039RN_0040",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA039RN-0040/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA039RN-0040/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA039RN-0040/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:39r"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA039VN_0541.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA039VN_0541.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA039VN_0541",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA039VN-0541/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA039VN-0541/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA039VN-0541/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:39v"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA040RN_0041.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA040RN_0041.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA040RN_0041",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA040RN-0041/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA040RN-0041/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA040RN-0041/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:40r"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA040VN_0542.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA040VN_0542.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA040VN_0542",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA040VN-0542/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA040VN-0542/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA040VN-0542/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:40v"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA041RN_0042.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA041RN_0042.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA041RN_0042",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA041RN-0042/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA041RN-0042/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA041RN-0042/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:41r"
     ],

--- a/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA041VN_0543.json
+++ b/data/annotations/image-annotations/image_annotation_tlg0012.tlg001.msA-folios-VA041VN_0543.json
@@ -7,7 +7,7 @@
     },
     "urn": "urn:cite2:hmt:vaimg.2017a:VA041VN_0543",
     "canvas_url": "https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA041VN-0543/canvas",
-    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA041VN-0543/full/full/0/default.jpg",
+    "image_url": "https://image.library.jhu.edu/iiif/homer%2FVA%2FVA041VN-0543/",
     "references": [
       "urn:cts:greekLit:tlg0012.tlg001.msA-folios:41v"
     ],


### PR DESCRIPTION
Prefer the Base URI as documented in the spec:

https://iiif.io/api/image/2.0/#uri-syntax