### PR TITLE
Passage metadata improvements

### DIFF
--- a/readhomer_atlas/library/passage.py
+++ b/readhomer_atlas/library/passage.py
@@ -1,0 +1,45 @@
+class Passage:
+    def __init__(self, start, end=None):
+        self.start = start
+        self.end = end
+
+    @staticmethod
+    def get_ranked_ancestors(obj):
+        return list(obj.get_ancestors().filter(rank__gt=0)) + [obj]
+
+    @staticmethod
+    def extract_human_readable_part(kind, ref):
+        return f"{kind.title()} {ref}"
+
+    @property
+    def human_readable_reference(self):
+        """
+        refs https://github.com/scaife-viewer/scaife-viewer/issues/69
+        Book 1 Line 1 to Book 1 Line 30
+        Book 1 Line 1 to Line 30
+        Book 1 to Book 2
+
+        Folio 12r Book 1 Line 1 to Line 6
+        """
+        start_objs = self.get_ranked_ancestors(self.start)
+
+        if self.end is None:
+            end_objs = start_objs
+        else:
+            end_objs = self.get_ranked_ancestors(self.end)
+
+        start_pieces = []
+        end_pieces = []
+        for start, end in zip(start_objs, end_objs):
+            start_pieces.append(
+                self.extract_human_readable_part(start.kind, start.lowest_citable_part)
+            )
+            if start.ref != end.ref:
+                end_pieces.append(
+                    self.extract_human_readable_part(end.kind, end.lowest_citable_part)
+                )
+        start_fragment = " ".join(start_pieces).strip()
+        end_fragment = " ".join(end_pieces).strip()
+        if end_fragment:
+            return " to ".join([start_fragment, end_fragment])
+        return start_fragment

--- a/readhomer_atlas/library/schema.py
+++ b/readhomer_atlas/library/schema.py
@@ -71,10 +71,19 @@ class LimitedConnectionField(DjangoFilterConnectionField):
 
 class PassageSiblingMetadataNode(ObjectType):
     # @@@ dry for resolving scalars
-    all_siblings = generic.GenericScalar(name="all")
-    selected = generic.GenericScalar()
-    previous = generic.GenericScalar()
-    next_siblings = generic.GenericScalar(name="next")
+    all_siblings = generic.GenericScalar(
+        name="all", description="Inclusive list of siblings for a passage"
+    )
+    selected = generic.GenericScalar(
+        description="Only the selected sibling objects for a given passage"
+    )
+    previous = generic.GenericScalar(description="Siblings for the previous passage")
+    next_siblings = generic.GenericScalar(
+        name="next", description="Siblings for the next passage"
+    )
+
+    class Meta:
+        description = "Provides lists of sibling objects for a given passage"
 
     def resolve_all_siblings(obj, info, **kwargs):
         return obj.all

--- a/readhomer_atlas/library/schema.py
+++ b/readhomer_atlas/library/schema.py
@@ -142,6 +142,7 @@ class PassageTextPartConnection(Connection):
 
     def resolve_metadata(self, info, *args, **kwargs):
         data = {}
+        # @@@ resolve metadata attrs individually
         passage = info.context.passage
         data.update(
             self.get_adjacent_passages(
@@ -150,13 +151,8 @@ class PassageTextPartConnection(Connection):
         )
         data["human_reference"] = passage.human_readable_reference
 
-        # @@@ resolve metadata.siblings|ancestors|children individually
         data["ancestors"] = self.get_ancestor_metadata(passage.version, passage.start)
-
-        data["siblings"] = PassageSiblingMetadata(passage).all
-
         data["children"] = self.get_children_metadata(passage.start)
-
         return camelize(data)
 
     def resolve_sibling_metadata(self, info, *args, **kwargs):

--- a/readhomer_atlas/library/schema.py
+++ b/readhomer_atlas/library/schema.py
@@ -19,6 +19,7 @@ from .models import (
     TextAnnotation,
     Token,
 )
+from .passage import Passage
 from .utils import (
     extract_version_urn_and_ref,
     filter_via_ref_predicate,
@@ -197,6 +198,10 @@ class PassageTextPartConnection(Connection):
             )
 
         data["children"] = self.get_children_metadata(start_obj)
+
+        passage = Passage(start_obj, end_obj)
+        data["human_reference"] = passage.human_readable_reference
+
         return camelize(data)
 
 


### PR DESCRIPTION
## What's in this PR?

**Moves `passageTextParts.metadata` from a Scalar to a proper GraphQL field**

This allows a site developer to specify _exactly_ which passage metadata should be returned.

This results in leaner queries (since ATLAS isn't computing and sending across the wire 
data that will not be used):


![image](https://user-images.githubusercontent.com/629062/88234951-7cfa3600-cc3f-11ea-8623-95ddc76ed20b.png)

**Pushes passage logic out to a proper `Passage` class**

This keeps the `schema.py` file a bit leaner, as we're doing more computation of data within the `Passage` instance (and will be helpful for #64)

**Further factors out sibling computations to `PassageSiblingMetadata` class**

Allows us to "bin" siblings into buckets  (`all|selected|previous|next|`) which will really simplify  ![](https://github.trello.services/images/mini-trello-icon.png) [Passage metadata improvements](https://trello.com/c/S1K7zE4h).

This also makes it easier to override sibling computations if we're using a MyCapytain resolver with an ATLAS server (ala Scholarly Editions)

**Computes a "human-readable" passage reference**

refs [scaife-viewer/scaife-viewer#69](https://github.com/scaife-viewer/scaife-viewer/issues/69)

## Sample query

[Preview Instance](https://explorehomer-feature-pa-evxn9d.herokuapp.com/graphql/#query=%7B%0A%20%20passageTextParts(reference%3A%20%22urn%3Acts%3AgreekLit%3Atlg0012.tlg001.perseus-grc2%3A7.205%22)%20%7B%0A%20%20%20%20metadata%20%7B%0A%20%20%20%20%20%20nextPassage%0A%20%20%20%20%20%20previousPassage%0A%20%20%20%20%20%20siblings%20%7B%0A%20%20%20%20%20%20%20%20all%0A%20%20%20%20%20%20%20%20selected%0A%20%20%20%20%20%20%20%20previous%0A%20%20%20%20%20%20%20%20next%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20ancestors%0A%20%20%20%20%20%20humanReference%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A)

_Query_:
```
{
  passageTextParts(reference: "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:7.205") {
    metadata {
      nextPassage
      previousPassage
      siblings {
        all
        selected
        previous
        next
      }
      ancestors
      humanReference
    }
  }
}
```

## Deployment Steps
- [ ] Wait until FE has passage metadata changes on `develop|master`
- [ ] Merge / deploy BE to match FE